### PR TITLE
Add link to addons.mozilla.org in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Tree Style Tab Focus Preceding Tab on Close
 This add-on requires [Tree Style Tab](https://github.com/piroor/treestyletab/).
+
+Link: [TST Focus Preceding Tab On Close on addons.mozilla.org](https://addons.mozilla.org/firefox/addon/tst-focus-preceding-tab)


### PR DESCRIPTION
It should be easier to get from here to the addon download page. Something like this link would help.