### PR TITLE
Fixed obsolete Tree Style Tab event.

### DIFF
--- a/background.js
+++ b/background.js
@@ -27,6 +27,7 @@ browser.runtime.onMessageExternal.addListener(function (aMessage, aSender) {
         case kTST_ID:
             switch (aMessage.type) {
                 case 'ready': {
+                    isTstTryFocusApiEnabled = false;    // TST might have been updated.
                     registerToTST(); // passive registration for secondary (or after) startup
                     console.log("TST registered");
                     return Promise.resolve(true);
@@ -154,7 +155,7 @@ async function cacheActiveTab(windowId, removedTabId = null, addedTabId = null) 
                 } catch (error) {
                     console.error('Failed to cache Tree Style Tab info for active tab.\nError', error);
                 }
-                if (tstTabInfo) Object.assign(activeTab, tstTabInfo);
+                if (tstTabInfo) activeTab.tstTab = tstTabInfo;
 
                 activeTab.timeWhenTabWasCached = Date.now();
             }
@@ -214,7 +215,7 @@ async function checkIfTabWasClosed(windowId, tabId) {
                 // console.log('Check tab: ', lastActiveTab.id);
 
                 if (lastActiveTab.id === tabId) {
-                    focusPrecedingChildTab(lastActiveTab);
+                    focusPrecedingChildTab(lastActiveTab.tstTab);
                     return;
                 }
 
@@ -276,7 +277,7 @@ browser.windows.getAll().then(value => {
 
 async function focusPrecedingChildTab(closedTab) {
     try {
-        if (closedTab.children && closedTab.children.length > 0) {
+        if (closedTab.children.length > 0) {
             console.log('Closed tab has children so focus on them.');
             return false;
         }

--- a/background.js
+++ b/background.js
@@ -1,164 +1,244 @@
 const kTST_ID = 'treestyletab@piro.sakura.ne.jp';
 
+function delay(timeInMilliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, timeInMilliseconds));
+}
+function deepCopy(data) {
+    return JSON.parse(JSON.stringify(data));
+}
+
 async function registerToTST() {
     try {
-        var success = await browser.runtime.sendMessage(kTST_ID, {
+        const success = await browser.runtime.sendMessage(kTST_ID, {
             type: 'register-self',
             name: self.id,
-            listeningTypes: ['try-move-focus-from-closing-current-tab'],
+            listeningTypes: ['ready', 'try-move-focus-from-closing-current-tab'],
         });
-        console.log("TST registered");
+        if (success) console.log("TST registered");
+        return true;
     }
-    catch (e) {
-        console.log("TST is not available");
-    }
+    catch (e) { }
+    console.log("TST is not available");
+    return false;
 }
 registerToTST();
 
-browser.runtime.onMessageExternal.addListener((aMessage, aSender) => {
+let isTstTryFocusApiEnabled = false;
+
+browser.runtime.onMessageExternal.addListener(function (aMessage, aSender) {
     switch (aSender.id) {
         case kTST_ID:
             switch (aMessage.type) {
-                case 'ready':
+                case 'ready': {
                     registerToTST(); // passive registration for secondary (or after) startup
                     console.log("TST registered");
                     return Promise.resolve(true);
-                case 'try-move-focus-from-closing-current-tab':
+                }
+                case 'try-move-focus-from-closing-current-tab': {
+                    // this API Event is obsolete and unavailable on TST 2.6.9 and later on Firefox 65 and newer versions
+                    isTstTryFocusApiEnabled = true;
+
                     console.log("current tab closing");
-                    let focusChanged = focusPrecedingChildTab(aMessage);
+                    let focusChanged = focusPrecedingChildTab(aMessage.tab);
                     focusChanged.then((value) => console.log('Blocked TST Default Tab Focus: ' + value));
                     return Promise.resolve(focusChanged);
+                }
             }
             break;
     }
 });
 
+/**
+ * @typedef {Object} CachedWindowInfo
+ * @property {number} Info.id The id of the window.
+ * @property {Object} Info.info The `windows.Window` object with info about the windows properties.
+ * @property {Array} Info.cache `tabs.Tab` objects for cached activate tabs in this window. There will only be one `tabs.Tab` object per tab id.
+ * @property {number} Info.indexOfLastAddedTab The index in the cache of the tab that was most recently added.
+ * @property {Promise<void>} Info.work A promise for the previous cache request. Used to ensure that the cache is updated in the right order.
+ */
+null;
 
-
-var windows = [];
+/**
+ * @type {Object.<string, CachedWindowInfo>}
+ */
+const windows = {};
 const cacheLength = 5;
 
 function getCachedWindow(windowId) {
-    let window = windows.filter(window => window.id === windowId);
-    if (window.length < 0) {
-        return null;
-    } else {
-        return window[0];
-    }
+    const window = windows[windowId];
+    if (!window) return null;
+    return window;
+}
+function getCachedWindowTabInChronologicalOrder(windowCache) {
+    const tabs = windowCache.cache.slice();
+    tabs.sort((a, b) => b.timeWhenTabWasCached - a.timeWhenTabWasCached);
+    return tabs;
 }
 async function cacheActiveTab(windowId, removedTabId = null, addedTabId = null) {
-    let window = getCachedWindow(windowId);
-    if (!window) {
-        return;
-    }
+    const window = getCachedWindow(windowId);
+    if (!window) return;
 
-    let previousWork = window.work;
-    let result = new Promise(async (resolve, reject) => {
+    const previousWork = window.work;
+    const result = (async () => {
         try {
-            let activeTab = await browser.tabs.query({ windowId: windowId, active: true });
-            activeTab = activeTab[0];
+            let activeTab;
+            if (addedTabId !== null) {
+                try {
+                    activeTab = await browser.tabs.get(addedTabId);
+                } catch (error) {
+                    console.error('Failed to get info for the tab that should be active.\nError:\n', error)
+                }
+            }
+            if (!activeTab) {
+                for (let iii = 0; iii < 5; iii++) {
+                    await delay(10);
+                    [activeTab,] = await browser.tabs.query({ windowId: windowId, active: true });
+                    if (
+                        (
+                            addedTabId === null ||
+                            activeTab.id === addedTabId.id
+                        ) &&
+                        (
+                            removedTabId === null ||
+                            activeTab.id !== removedTabId.id
+                        )
+                    ) {
+                        break;
+                    }
+                }
+            }
+
+            if (!isTstTryFocusApiEnabled) {
+                let tstTabInfo;
+                try {
+                    tstTabInfo = await browser.runtime.sendMessage(kTST_ID, {
+                        type: 'get-tree',
+                        tab: activeTab.id,
+                    });
+                } catch (error) {
+                    console.error('Failed to cache Tree Style Tab info for active tab.\nError', error);
+                }
+                if (tstTabInfo) Object.assign(activeTab, tstTabInfo);
+
+                activeTab.timeWhenTabWasCached = Date.now();
+            }
 
             try {
                 await previousWork;
             } catch (error) { }
 
 
-            if (!window.ignore) {
-                window.ignore = [];
-            }
-            if ((removedTabId || removedTabId === 0) && !window.ignore.includes(removedTabId)) {
-                window.ignore.push(removedTabId);
-            }
-            if ((addedTabId || addedTabId === 0) && window.ignore.includes(addedTabId)) {
-                window.ignore = window.ignore.filter(tabId => tabId !== addedTabId);
-            }
-
-            if (window.ignore.includes(activeTab.id)) {
-                resolve();
-                return;
-            }
-
-            if (!window.iii) {
-                window.iii = 0;
+            if (!window.indexOfLastAddedTab) {
+                window.indexOfLastAddedTab = 0;
             }
 
             if (!window.cache) {
                 // console.log('first cached tab');
                 window.cache = [activeTab];
-                window.iii = 1;
             } else {
                 let tabIndex = window.cache.map(tab => tab.id).indexOf(activeTab.id);
                 if (tabIndex < 0) {
                     // console.log('new tab cached');
-                    if (window.iii >= cacheLength) {
-                        window.iii = 0;
+                    window.indexOfLastAddedTab++;
+                    if (window.indexOfLastAddedTab >= cacheLength) {
+                        window.indexOfLastAddedTab = 0;
                     }
-                    window.cache.splice(window.iii, window.cache.length > window.iii ? 1 : 0, activeTab);
-                    window.iii++;
+                    window.cache.splice(window.indexOfLastAddedTab, window.cache.length > window.indexOfLastAddedTab ? 1 : 0, activeTab);
                 } else {
                     // console.log('cached tab updated');
                     window.cache[tabIndex] = activeTab;
                 }
             }
-            resolve();
         } catch (error) {
-            console.log('Failed to cache active tab:\n' + error);
-            reject(error);
+            console.error('Failed to cache active tab:\n' + error);
         }
-    });
+    })();
     window.work = result;
     return result;
 }
 
-browser.tabs.onActivated.addListener((activeInfo) => {
-    cacheActiveTab(activeInfo.windowId);
+browser.tabs.onActivated.addListener(function ({ windowId, previousTabId, tabId }) {
+    cacheActiveTab(windowId, null, tabId);
 });
-browser.tabs.onMoved.addListener((tabId, moveInfo) => {
+browser.tabs.onMoved.addListener(function (tabId, moveInfo) {
     cacheActiveTab(moveInfo.windowId);
 });
 
-browser.tabs.onCreated.addListener((tab) => {
+async function checkIfTabWasClosed(windowId, tabId) {
+    if (!isTstTryFocusApiEnabled) {
+        const windowCache = getCachedWindow(windowId);
+        if (windowCache) {
+            const now = Date.now();
+
+            await windowCache.work;
+            const tabs = getCachedWindowTabInChronologicalOrder(windowCache);
+            for (const lastActiveTab of tabs) {
+                console.log('Check tab: ', lastActiveTab.id);
+
+                if (lastActiveTab.id === tabId) {
+                    focusPrecedingChildTab(lastActiveTab);
+                    return;
+                }
+
+                const timeSinceCached = now - lastActiveTab.timeWhenTabWasCached;
+                if (timeSinceCached > 500) {
+                    // This tab's active status wasn't changed recently => the previous cached active tab hasn't been active for at least that time => don't check any more cached tabs.
+                    console.log('tab wasn\'t active for: ', timeSinceCached, '\nTabId: ', lastActiveTab.id);
+                    break;
+                }
+            }
+        }
+        console.log('Tab was closed but it wasn\'t active.\nTabId ', tabId, '\nWindowId: ', windowId, '\nwindowCache: ', JSON.parse(JSON.stringify(windowCache)));
+    }
+}
+
+browser.tabs.onCreated.addListener(function (tab) {
     cacheActiveTab(tab.windowId, null, tab.id);
 });
-browser.tabs.onRemoved.addListener((tabId, removeInfo) => {
-    cacheActiveTab(removeInfo.windowId, tabId);
+browser.tabs.onRemoved.addListener(function (tabId, { isWindowClosing, windowId }) {
+    if (isWindowClosing) return;
+    checkIfTabWasClosed(windowId, tabId);
+    cacheActiveTab(windowId, tabId);
 });
 
-browser.tabs.onDetached.addListener((tabId, detachInfo) => {
+browser.tabs.onDetached.addListener(function (tabId, detachInfo) {
+    checkIfTabWasClosed(detachInfo.oldWindowId, tabId);
     cacheActiveTab(detachInfo.oldWindowId, tabId);
 });
-browser.tabs.onAttached.addListener((tabId, attachInfo) => {
+browser.tabs.onAttached.addListener(function (tabId, attachInfo) {
     cacheActiveTab(attachInfo.newWindowId, null, tabId);
 });
 
-browser.windows.onCreated.addListener((window) => {
-    windows.push({
-        id: window.id,
-        info: window,
-    });
-    cacheActiveTab(window.id);
+browser.windows.onCreated.addListener(function (window) {
+    if (!getCachedWindow(window.id)) {
+        windows[window.id] = {
+            id: window.id,
+            info: window,
+        };
+        cacheActiveTab(window.id);
+    }
 });
-browser.windows.onRemoved.addListener((windowId) => {
-    windows = windows.filter(window => window.id !== windowId);
+browser.windows.onRemoved.addListener(function (windowId) {
+    delete windows[windowId];
 });
 
 browser.windows.getAll().then(value => {
-    for (let window of value) {
+    for (const window of value) {
         if (!getCachedWindow(window.id)) {
-            windows.push({
+            windows[window.id] = {
                 id: window.id,
                 info: window,
-            });
+            };
+            cacheActiveTab(window.id);
         }
     }
 });
 
 
 
-async function focusPrecedingChildTab(aMessage) {
+async function focusPrecedingChildTab(closedTab) {
     try {
-        var closedTab = aMessage.tab;
-        if (closedTab.children.length > 0) {
+        if (closedTab.children && closedTab.children.length > 0) {
             console.log('Closed tab has children so focus on them.');
             return false;
         }
@@ -168,23 +248,22 @@ async function focusPrecedingChildTab(aMessage) {
         await cachedWindow.work;
         let closedNativeTab = cachedWindow.cache.filter(tab => tab.id === closedTab.id);
 
-        activeNativeTab = await browser.tabs.query({
+        const [activeNativeTab,] = await browser.tabs.query({
             windowId: closedTab.windowId,
             active: true,
         });
-        activeNativeTab = activeNativeTab[0];
 
         // Use active tab's index if closed tab can't be found:
         if (closedNativeTab.length === 0) {
-            console.log('Closed tab not cached. Using active tab instead.')
+            console.log('Closed tab not cached. Using active tab instead.');
             closedNativeTab = activeNativeTab;
         }
         closedNativeTab = Array.isArray(closedNativeTab) ? closedNativeTab[0] : closedNativeTab;
-        var index = closedNativeTab.index - 1;
+        let index = closedNativeTab.index - 1;
 
         // Find previous tab:
-        var getPreviousTab = async (windowId, index) => {
-            tabs = await browser.tabs.query({
+        const getPreviousTab = async (windowId, index) => {
+            const tabs = await browser.tabs.query({
                 windowId: windowId,
                 index: index < 0 ? -index : index,
             });
@@ -193,7 +272,7 @@ async function focusPrecedingChildTab(aMessage) {
             } else {
                 throw new Error('No tab at requested index.');
             }
-        }
+        };
         var precedingNativeTab = await getPreviousTab(closedTab.windowId, index);
         if (precedingNativeTab.id === closedTab.id) {
             precedingNativeTab = await getPreviousTab(closedTab.windowId, --index);
@@ -204,7 +283,7 @@ async function focusPrecedingChildTab(aMessage) {
             return true;
         }
 
-        var tabIdToFocus = null;
+        let tabIdToFocus = null;
         if (precedingNativeTab.index > 0) {
             var precedingTab = await browser.runtime.sendMessage(kTST_ID, {
                 type: 'get-tree',
@@ -245,9 +324,12 @@ async function focusPrecedingChildTab(aMessage) {
             throw new Error('Failed to find focus target tab.');
         }
         console.log("Focusing preceding tab");
-        await browser.tabs.update(tabIdToFocus, { active: true });
+        for (let iii = 0; iii < 1; iii++) {
+            await browser.tabs.update(tabIdToFocus, { active: true });
+            await delay(250);
+        }
     } catch (error) {
-        console.log('Failed to focus on preceding tab:\n' + error);
+        console.error('Failed to focus on preceding tab:\n' + error);
         return false;
     }
     return true;


### PR DESCRIPTION
The `try-move-focus-from-closing-current-tab` Tree Style Tab event that was sent when an active tab was closed is [unavailable on latest versions of Tree Style Tab](https://github.com/piroor/treestyletab/wiki/API-for-other-addons#when-the-current-tab-is-closed). 

This pull request refactors the code to manually detect when a closed tab is active and then handles it. Tree Style Tab info for the closed tab is also cached since it is no longer provided from the Tree Style Tab event. 

This pull request should fix #5. 